### PR TITLE
Add ability to edit and delete events

### DIFF
--- a/app/components/day-calendar.js
+++ b/app/components/day-calendar.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-const { observer, computed, Component, inject } = Ember;
+import moment from 'moment';
+const { observer, computed, Component, inject, $ } = Ember;
 
 export default Component.extend({
   store: inject.service(),
@@ -48,7 +49,7 @@ export default Component.extend({
       maxTime: this.get('maxTime'),
       selectable: true,
       select: (start, end) => {
-        this.get('openCreateEventModal')({ start: start, end: end });
+        this.get('openEventModal')({ start: start, end: end });
       },
       editable: true,
       eventDrop: (event) => {
@@ -56,6 +57,14 @@ export default Component.extend({
       },
       eventResize: (event) => {
         this.get('updateEvent')(event.id, { start: event.start, end: event.end });
+      },
+      eventRender: (event, element) => {
+        element.find('.fc-time').append("<i class='fa fa-pencil-square-o u-float-right fc-edit-icon'/>");
+      },
+      eventClick: (event, jsEvent) => {
+        if ($('.fc-edit-icon').is(jsEvent.target)) {
+          this.get('openEventModal')({ id: event.id, start: event.start, end: event.end, name: event.title });
+        }
       }
     });
   },

--- a/app/components/modals/create-event-modal.js
+++ b/app/components/modals/create-event-modal.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
 
   // passed variables
   showModal: null,
-  newEvent: null,
+  formEvent: null,
 
   actions: {
     closeModal() {

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -8,7 +8,7 @@ export default Controller.extend({
     return moment(this.get('activeDate')).format('LL');
   }),
   showCreateEventModal: false,
-  newEvent: computed(() => { return {}; }),
+  formEvent: {},
   events: computed('model.events.[]', 'model.events.@each.start', 'model.events.@each.end', 'model.events.@each.name', function() {
     return this.get('model.events').map((event) => {
       return event.get('fullCalendarFormat');
@@ -19,9 +19,8 @@ export default Controller.extend({
     setActiveDate(newActiveDate) {
       this.set('activeDate', newActiveDate);
     },
-    openCreateEventModal(eventObject) {
-      this.set('newEvent.start', eventObject.start);
-      this.set('newEvent.end', eventObject.end);
+    openEventModal(eventObject) {
+      this.set('formEvent', eventObject);
       this.toggleProperty('showCreateEventModal');
     },
     updateEvent(eventId, eventProperties) {

--- a/app/models/event.js
+++ b/app/models/event.js
@@ -20,8 +20,8 @@ export default DS.Model.extend({
   fullCalendarFormat: computed('start', 'end', 'name', 'id', function() {
     return {
       title: this.get('name'),
-      start: new Date(this.get('start')),
-      end: new Date(this.get('end')),
+      start: this.get('start'),
+      end: this.get('end'),
       id: this.get('id')
     };
   })

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -18,3 +18,8 @@
 
 // Templates
 @import 'templates/home';
+
+// Utilities
+.u-float-right {
+  float: right;
+}

--- a/app/styles/components/day-calendar.scss
+++ b/app/styles/components/day-calendar.scss
@@ -23,6 +23,15 @@ day-calendar {
     background-color: rgba(75, 186, 247, 0.79);
   }
 
+  .fc-edit-icon {
+    font-size: 20px;
+    opacity: 0.5;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
   .fc-day-header {
     color: white;
   }

--- a/app/styles/components/forms/create-event-form.scss
+++ b/app/styles/components/forms/create-event-form.scss
@@ -12,6 +12,15 @@ create-event-form {
   display: block;
   padding: 20px;
 
+  .event-form__delete {
+    color: $color-light-red;
+    font-size: 12px;
+    display: block;
+    text-align: center;
+    padding: 10px 0;
+    cursor: pointer;
+  }
+
   .s-btn {
     padding: 10px;
     font-size: 20px;

--- a/app/templates/components/forms/create-event-form.hbs
+++ b/app/templates/components/forms/create-event-form.hbs
@@ -1,7 +1,8 @@
 <form>
   {{s-input value=formData.name
     placeholder='Event name...'
-    errors=errors.name}}
+    errors=errors.name
+    class='event-form__name'}}
 
   {{s-input value=formData.date
     label='Date:'
@@ -18,7 +19,8 @@
     typeIsTime=true
     errors=errors.endTime}}
 
-  <button class='s-btn' {{action 'saveEvent'}}>
+  <button class='s-btn' {{action 'submitForm'}}>
     <span class='s-btn__text'>save</span>
   </button>
+  <a class='event-form__delete' {{action 'deleteEvent'}}>delete event</a>
 </form>

--- a/app/templates/components/modals/create-event-modal.hbs
+++ b/app/templates/components/modals/create-event-modal.hbs
@@ -4,7 +4,7 @@
                   wrapperClassNames='wrapppppper'
                   translucentOverlay=true}}
     {{forms/create-event-form
-      newEvent=newEvent
+      formEvent=formEvent
       closeModal=(action 'closeModal')}}
   {{/modal-dialog}}
 {{/if}}

--- a/app/templates/home.hbs
+++ b/app/templates/home.hbs
@@ -13,7 +13,7 @@
       {{day-calendar
         events=events
         activeDate=activeDate
-        openCreateEventModal=(action 'openCreateEventModal')
+        openEventModal=(action 'openEventModal')
         updateEvent=(action 'updateEvent')}}
     </div>
   </div>
@@ -21,4 +21,4 @@
 
 {{modals/create-event-modal
   showModal=showCreateEventModal
-  newEvent=newEvent}}
+  formEvent=formEvent}}

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "shotgun-web",
   "dependencies": {
     "ember": "~2.9.0",
-    "ember-cli-shims": "0.1.3"
+    "ember-cli-shims": "0.1.3",
+    "font-awesome": "~4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.9.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-font-awesome": "2.2.0",
     "ember-load-initializers": "^0.5.1",
     "ember-modal-dialog": "0.9.0",
     "ember-moment": "6.1.0",


### PR DESCRIPTION
Note to self - event dates coming from FullCalendar can be saved to the store models and it'll work nicely with `DS.utc`. If parsing regular date strings, however, don't forget to use the `parseZone` function.

Ignored bugs:
1. Edit icon doesn't float right when the event is only 30 minutes.
2. Edit icon is unclickable with stacked events.

`create-event-form.js` is starting to get unruly, but you knew that. Similar update function in `home.js` as in `create-event-form.js` - might be able to reduce these.